### PR TITLE
Update Primary Branch References in the Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ git remote add upstream git@github.com:fastapi/full-stack-fastapi-template.git
 - Push the code to your new repository:
 
 ```bash
-git push -u origin master
+git push -u origin main
 ```
 
 ### Update From the Original Template
@@ -107,7 +107,7 @@ upstream    git@github.com:fastapi/full-stack-fastapi-template.git (push)
 - Pull the latest changes without merging:
 
 ```bash
-git pull --no-commit upstream master
+git pull --no-commit upstream main
 ```
 
 This will download the latest changes from this template without committing them, that way you can check everything is right before committing.

--- a/deployment.md
+++ b/deployment.md
@@ -275,7 +275,7 @@ The current Github Actions workflows expect these secrets:
 
 There are GitHub Action workflows in the `.github/workflows` directory already configured for deploying to the environments (GitHub Actions runners with the labels):
 
-* `staging`: after pushing (or merging) to the branch `master`.
+* `staging`: after pushing (or merging) to the branch `main`.
 * `production`: after publishing a release.
 
 If you need to add extra environments you could use those as a starting point.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -66,7 +66,7 @@ The project includes three main CI workflows that run on every pull request:
 - Generates coverage report (requires 90%+ coverage)
 
 **When it runs**:
-- On push to `master` branch
+- On push to `main` branch
 - On pull request open or sync
 
 **Duration**: ~2-3 minutes
@@ -80,7 +80,7 @@ The project includes three main CI workflows that run on every pull request:
 - Runs tests in parallel across 4 shards for speed
 
 **When it runs**:
-- On push to `master` branch
+- On push to `main` branch
 - On pull request open or sync
 - Only if relevant files changed (backend, frontend, docker configs)
 
@@ -95,7 +95,7 @@ The project includes three main CI workflows that run on every pull request:
 - Health checks all services
 
 **When it runs**:
-- On push to `master` branch
+- On push to `main` branch
 - On pull request open or sync
 
 **Duration**: ~3-4 minutes
@@ -368,7 +368,7 @@ To temporarily disable a workflow without deleting it:
    on:
      push:
        branches:
-         - master
+         - main
 
    jobs:
      test-backend:

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -256,7 +256,7 @@ Choose one:
   ```
 - [ ] Correct branch/tag checked out
   ```bash
-  git checkout v1.0.0  # or main/master
+  git checkout v1.0.0  # or main
   ```
 
 ### Build & Start

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -24,7 +24,7 @@ graph TB
 
     Build --> Decision{Branch?}
 
-    Decision -->|main/master| Staging[Deploy to Staging]
+    Decision -->|main| Staging[Deploy to Staging]
     Decision -->|release tag| Prod[Deploy to Production]
     Decision -->|other| End[End]
 


### PR DESCRIPTION
The replacement of `master` with the value `main` in all of the documentation has been completed. 

(See Ticket #19)